### PR TITLE
fix(schema): remove non-GLB asset types

### DIFF
--- a/schemas/gltf-asset.schema.json
+++ b/schemas/gltf-asset.schema.json
@@ -12,26 +12,19 @@
       "enum": [
         "beard",
         "bottom",
-        "eye",
-        "eyebrows",
-        "eyeshape",
-        "facemask",
-        "faceshape",
         "facewear",
         "footwear",
         "glasses",
         "hair",
         "headwear",
-        "lipshape",
         "costume",
-        "noseshape",
         "outfit",
         "shirt",
         "top"
       ],
       "errorMessage": {
         "type": "Asset type should be a string.",
-        "enum": "Asset type should be one of the following: beard, bottom, eye, eyebrows, eyeshape, facemask, faceshape, facewear, footwear, glasses, hair, headwear, lipshape, costume, noseshape, outfit, shirt, top. Found ${0}."
+        "enum": "Asset type should be one of the following: beard, bottom, facemask, facewear, footwear, glasses, hair, headwear, costume, outfit, shirt, top. Found ${0}."
       }
     },
     "transforms": {


### PR DESCRIPTION
Remove asset types that are not based on GLB files and, therefore, cannot be validated by this schema.

Issue: TECHART-336