### PR TITLE
fix: add support for u16 joint indices in meshAttributes schema

### DIFF
--- a/schemas/meshAttributes.schema.json
+++ b/schemas/meshAttributes.schema.json
@@ -29,6 +29,7 @@
         "type": "string",
         "enum": [
           "JOINTS_0:u8",
+          "JOINTS_0:u16",
           "NORMAL:f32",
           "POSITION:f32",
           "TEXCOORD_0:f32",
@@ -39,7 +40,7 @@
       },
       "contains": {
         "type": "string",
-        "pattern": "JOINTS_0:u8|NORMAL:f32|POSITION:f32|TEXCOORD_0:f32|WEIGHTS_0:f32",
+        "pattern": "JOINTS_0:u8|JOINTS_0:u16|NORMAL:f32|POSITION:f32|TEXCOORD_0:f32|WEIGHTS_0:f32",
         "errorMessage": "Mesh ${2/name} requires at least 5 vertex attributes: position, normal, 1 UV set, joint influences, and weights. Found ${1/length} attributes: ${1}."
       },
       "minContains": 5,


### PR DESCRIPTION
Partners that do not use Blender to export to GLB, but e.g. Unity or Cinema4D face issues with the joints attribute in the GLB being of type u16. I only allowed u8 because this is what Blender exports and I was not expecting more than 256 joints in the skeleton anytime soon. But u16 is what other exporters use apparently, and it is valid gltf 2.0 spec.

Adding support for JOINTS_0:u16 mesh attribute unblocks these partners to upload their outfits.

Task: TECHART-354