### PR TITLE
fix: expand bounding box to 3m width and depth

### DIFF
--- a/schemas/scene.schema.json
+++ b/schemas/scene.schema.json
@@ -120,21 +120,21 @@
           "prefixItems": [
             {
               "type": "number",
-              "minimum": -1.0,
+              "minimum": -1.5,
               "maximum": 0.0,
-              "errorMessage": "Bounding Box X minimum for body area must be between -1.0 and 0.0. Found ${0} and index ${0#}"
+              "errorMessage": "Bounding Box X minimum for body area must be between -1.5 and 0.0. Found ${0} for index ${0#}"
             },
             {
               "type": "number",
               "minimum": -0.1,
               "maximum": 1.5,
-              "errorMessage": "Bounding Box Y minimum for body area must be between -0.1 and 0.5. Found ${0} and index ${0#}"
+              "errorMessage": "Bounding Box Y minimum for body area must be between -0.1 and 0.5. Found ${0} for index ${0#}"
             },
             {
               "type": "number",
-              "minimum": -1.0,
+              "minimum": -1.5,
               "maximum": 0.0,
-              "errorMessage": "Bounding Box Z minimum for body area must be between -1.0 and 0.0. Found ${0} and index ${0#}"
+              "errorMessage": "Bounding Box Z minimum for body area must be between -1.5 and 0.0. Found ${0} for index ${0#}"
             }
           ],
           "items": false,
@@ -148,20 +148,20 @@
             {
               "type": "number",
               "minimum": 0.0,
-              "maximum": 1.0,
-              "errorMessage": "Bounding Box Z maximum for body area must be between 0.0 and 1.0. Found ${0} and index ${0#}"
+              "maximum": 1.5,
+              "errorMessage": "Bounding Box Z maximum for body area must be between 0.0 and 1.5. Found ${0} for index ${0#}"
             },
             {
               "type": "number",
               "minimum": 0.0,
               "maximum": 3.0,
-              "errorMessage": "Bounding Box Z maximum for body area must be between 0.0 and 3.0. Found ${0} and index ${0#}"
+              "errorMessage": "Bounding Box Z maximum for body area must be between 0.0 and 3.0. Found ${0} for index ${0#}"
             },
             {
               "type": "number",
               "minimum": 0.0,
-              "maximum": 1.0,
-              "errorMessage": "Bounding Box Z maximum for body area must be between 0.0 and 1.0. Found ${0} and index ${0#}"
+              "maximum": 1.5,
+              "errorMessage": "Bounding Box Z maximum for body area must be between 0.0 and 1.5. Found ${0} for index ${0#}"
             }
           ],
           "items": false,


### PR DESCRIPTION
Some hero characters take more space, e.g. when having a tail. Expand the bounding box in X and Z direction by 0.5m to each side, so it's 3x3x3m in total. 