### PR TITLE
feat(materials): allow any alpha mode on materials

### DIFF
--- a/schemas/assetBeard.schema.json
+++ b/schemas/assetBeard.schema.json
@@ -62,7 +62,7 @@
                 "$ref": "commonMaterial.schema.json#/$defs/singleSided"
               },
               "alphaMode": {
-                "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"
+                "$ref": "commonMaterial.schema.json#/$defs/anyAlphaMode"
               }
             },
             "allOf": [{ "$ref": "commonMaterial.schema.json" }],

--- a/schemas/assetBottom.schema.json
+++ b/schemas/assetBottom.schema.json
@@ -68,7 +68,7 @@
                 "$ref": "commonMaterial.schema.json#/$defs/anySided"
               },
               "alphaMode": {
-                "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"
+                "$ref": "commonMaterial.schema.json#/$defs/anyAlphaMode"
               }
             },
             "allOf": [{ "$ref": "commonMaterial.schema.json" }],

--- a/schemas/assetCostume.schema.json
+++ b/schemas/assetCostume.schema.json
@@ -68,6 +68,9 @@
               },
               "doubleSided": {
                 "$ref": "commonMaterial.schema.json#/$defs/anySided"
+              },
+              "alphaMode": {
+                "$ref": "commonMaterial.schema.json#/$defs/anyAlphaMode"
               }
             },
             "allOf": [
@@ -103,27 +106,6 @@
                 },
                 "else": {
                   "$ref": "commonMaterial.schema.json"
-                }
-              },
-              {
-                "if": {
-                  "properties": {
-                    "name": { "const": "Wolf3D_Glasses" }
-                  }
-                },
-                "then": {
-                  "properties": {
-                    "alphaMode": {
-                      "$ref": "commonMaterial.schema.json#/$defs/anyAlphaMode"
-                    }
-                  }
-                },
-                "else": {
-                  "properties": {
-                    "alphaMode": {
-                      "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"
-                    }
-                  }
                 }
               }
             ],

--- a/schemas/assetFootwear.schema.json
+++ b/schemas/assetFootwear.schema.json
@@ -68,7 +68,7 @@
                 "$ref": "commonMaterial.schema.json#/$defs/anySided"
               },
               "alphaMode": {
-                "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"
+                "$ref": "commonMaterial.schema.json#/$defs/anyAlphaMode"
               }
             },
             "allOf": [{ "$ref": "commonMaterial.schema.json" }],

--- a/schemas/assetHair.schema.json
+++ b/schemas/assetHair.schema.json
@@ -62,7 +62,7 @@
                 "$ref": "commonMaterial.schema.json#/$defs/singleSided"
               },
               "alphaMode": {
-                "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"
+                "$ref": "commonMaterial.schema.json#/$defs/anyAlphaMode"
               }
             },
             "allOf": [{ "$ref": "commonMaterial.schema.json" }],

--- a/schemas/assetOutfit.schema.json
+++ b/schemas/assetOutfit.schema.json
@@ -67,9 +67,6 @@
               },
               "textures": {
                 "description": "Textures used by the outfit materials. The 'Wolf3D_Body' material uses only the 'normalTexture'. All other materials can use all channels."
-              },
-              "alphaMode": {
-                "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"
               }
             },
             "allOf": [
@@ -89,6 +86,9 @@
                     },
                     "doubleSided": {
                       "$ref": "commonMaterial.schema.json#/$defs/singleSided"
+                    },
+                    "alphaMode": {
+                      "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"
                     }
                   }
                 },
@@ -99,6 +99,9 @@
                     },
                     "doubleSided": {
                       "$ref": "commonMaterial.schema.json#/$defs/anySided"
+                    },
+                    "alphaMode": {
+                      "$ref": "commonMaterial.schema.json#/$defs/anyAlphaMode"
                     }
                   }
                 }

--- a/schemas/assetShirt.schema.json
+++ b/schemas/assetShirt.schema.json
@@ -62,7 +62,7 @@
                 "$ref": "commonMaterial.schema.json#/$defs/singleSided"
               },
               "alphaMode": {
-                "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"
+                "$ref": "commonMaterial.schema.json#/$defs/anyAlphaMode"
               }
             },
             "allOf": [{ "$ref": "commonMaterial.schema.json" }],

--- a/schemas/assetTop.schema.json
+++ b/schemas/assetTop.schema.json
@@ -68,7 +68,7 @@
                 "$ref": "commonMaterial.schema.json#/$defs/anySided"
               },
               "alphaMode": {
-                "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"
+                "$ref": "commonMaterial.schema.json#/$defs/anyAlphaMode"
               }
             },
             "allOf": [{ "$ref": "commonMaterial.schema.json" }],


### PR DESCRIPTION
Because there were previous issues with transparency, we enforced opaque alpha mode for most of the materials. This PR lifts this restriction for most of the materials.

Note: While this allows to upload materials with any alpha mode, if different materials use different alpha modes, e.g. MASK and BLEND, the resulting texture-atlas material will use BLEND alpha mode.