### PR TITLE
fix(joints): allow skeleton with eye-joints for modular assets

### DIFF
--- a/schemas/assetBottom.schema.json
+++ b/schemas/assetBottom.schema.json
@@ -93,18 +93,9 @@
     "animations": { "$ref": "animation.schema.json#/properties/noAnimation" },
     "joints": {
       "anyOf": [
-        {
-          "allOf": [
-            { "$ref": "joints.schema.json#/$defs/skeletonV2" },
-            { "$ref": "joints.schema.json#/$defs/skeletonV2/$defs/maxJoints" }
-          ]
-        },
-        {
-          "allOf": [
-            { "$ref": "joints.schema.json#/$defs/skeletonXr" },
-            { "$ref": "joints.schema.json#/$defs/skeletonXr/$defs/maxJoints" }
-          ]
-        }
+        { "$ref": "joints.schema.json#/$defs/skeletonV2" },
+        { "$ref": "joints.schema.json#/$defs/skeletonV2WithEyes" },
+        { "$ref": "joints.schema.json#/$defs/skeletonXr" }
       ]
     }
   },

--- a/schemas/assetCostume.schema.json
+++ b/schemas/assetCostume.schema.json
@@ -131,15 +131,8 @@
     "animations": { "$ref": "animation.schema.json#/properties/noAnimation" },
     "joints": {
       "anyOf": [
-        {
-          "$ref": "joints.schema.json#/$defs/skeletonV2WithEyes"
-        },
-        {
-          "allOf": [
-            { "$ref": "joints.schema.json#/$defs/skeletonXr" },
-            { "$ref": "joints.schema.json#/$defs/skeletonXr/$defs/maxJoints" }
-          ]
-        }
+        { "$ref": "joints.schema.json#/$defs/skeletonV2WithEyes" },
+        { "$ref": "joints.schema.json#/$defs/skeletonXr" }
       ]
     }
   },

--- a/schemas/assetFootwear.schema.json
+++ b/schemas/assetFootwear.schema.json
@@ -93,18 +93,9 @@
     "animations": { "$ref": "animation.schema.json#/properties/noAnimation" },
     "joints": {
       "anyOf": [
-        {
-          "allOf": [
-            { "$ref": "joints.schema.json#/$defs/skeletonV2" },
-            { "$ref": "joints.schema.json#/$defs/skeletonV2/$defs/maxJoints" }
-          ]
-        },
-        {
-          "allOf": [
-            { "$ref": "joints.schema.json#/$defs/skeletonXr" },
-            { "$ref": "joints.schema.json#/$defs/skeletonXr/$defs/maxJoints" }
-          ]
-        }
+        { "$ref": "joints.schema.json#/$defs/skeletonV2" },
+        { "$ref": "joints.schema.json#/$defs/skeletonV2WithEyes" },
+        { "$ref": "joints.schema.json#/$defs/skeletonXr" }
       ]
     }
   },

--- a/schemas/assetOutfit.schema.json
+++ b/schemas/assetOutfit.schema.json
@@ -129,33 +129,13 @@
     "animations": { "$ref": "animation.schema.json#/properties/noAnimation" },
     "joints": {
       "anyOf": [
-        {
-          "allOf": [
-            {
-              "$ref": "joints.schema.json#/$defs/skeletonV2"
-            },
-            {
-              "$ref": "joints.schema.json#/$defs/skeletonV2/$defs/maxJoints"
-            }
-          ]
-        },
-        {
-          "$ref": "joints.schema.json#/$defs/skeletonV2WithEyes"
-        },
-        {
-          "allOf": [
-            {
-              "$ref": "joints.schema.json#/$defs/skeletonXr"
-            },
-            {
-              "$ref": "joints.schema.json#/$defs/skeletonXr/$defs/maxJoints"
-            }
-          ]
-        }
+        { "$ref": "joints.schema.json#/$defs/skeletonV2" },
+        { "$ref": "joints.schema.json#/$defs/skeletonV2WithEyes" },
+        { "$ref": "joints.schema.json#/$defs/skeletonXr" }
       ]
     }
   },
-  "required": ["scenes", "meshes", "materials", "joints"],
+  "required": ["scenes", "meshes", "materials", "textures", "joints"],
   "$defs": {
     "outfitTextureCount": {
       "type": "object",

--- a/schemas/assetTop.schema.json
+++ b/schemas/assetTop.schema.json
@@ -93,18 +93,9 @@
     "animations": { "$ref": "animation.schema.json#/properties/noAnimation" },
     "joints": {
       "anyOf": [
-        {
-          "allOf": [
-            { "$ref": "joints.schema.json#/$defs/skeletonV2" },
-            { "$ref": "joints.schema.json#/$defs/skeletonV2/$defs/maxJoints" }
-          ]
-        },
-        {
-          "allOf": [
-            { "$ref": "joints.schema.json#/$defs/skeletonXr" },
-            { "$ref": "joints.schema.json#/$defs/skeletonXr/$defs/maxJoints" }
-          ]
-        }
+        { "$ref": "joints.schema.json#/$defs/skeletonV2" },
+        { "$ref": "joints.schema.json#/$defs/skeletonV2WithEyes" },
+        { "$ref": "joints.schema.json#/$defs/skeletonXr" }
       ]
     }
   },

--- a/schemas/gltf-asset.schema.json
+++ b/schemas/gltf-asset.schema.json
@@ -80,7 +80,9 @@
     },
     {
       "if": {
-        "properties": { "assetType": { "const": "bottom" } }
+        "properties": { "assetType": { "const": "bottom" } },
+        "required": ["assetType"]
+
       },
       "then": {
         "allOf": [
@@ -107,7 +109,8 @@
     },
     {
       "if": {
-        "properties": { "assetType": { "const": "footwear" } }
+        "properties": { "assetType": { "const": "footwear" } },
+        "required": ["assetType"]
       },
       "then": {
         "allOf": [
@@ -176,7 +179,8 @@
     },
     {
       "if": {
-        "properties": { "assetType": { "const": "top" } }
+        "properties": { "assetType": { "const": "top" } },
+        "required": ["assetType"]
       },
       "then": {
         "allOf": [


### PR DESCRIPTION
refactored joints schema to more easily add skeletons to asset schemas. skeletonXr now extends skeletonV2 instead of a complete redefinition.