### PR TITLE
fix(headwear): allow Armature instead of Headwear_Rig as skeleton names

### DIFF
--- a/schemas/joints.schema.json
+++ b/schemas/joints.schema.json
@@ -16,7 +16,7 @@
       "description": "Headwear skeleton hierarchy.",
       "type": "object",
       "properties": {
-        "Spine": { "type": "string", "const": "Headwear_Rig" },
+        "Spine": { "type": "string", "enum": ["Headwear_Rig", "Armature"] },
         "Neck": { "type": "string", "const": "Spine" },
         "Head": { "type": "string", "const": "Neck" }
       },

--- a/schemas/joints.schema.json
+++ b/schemas/joints.schema.json
@@ -16,7 +16,7 @@
       "description": "Headwear skeleton hierarchy.",
       "type": "object",
       "properties": {
-        "Spine": { "type": "string", "enum": ["Headwear_Rig", "Armature"] },
+        "Spine": { "type": "string", "const": "Armature" },
         "Neck": { "type": "string", "const": "Spine" },
         "Head": { "type": "string", "const": "Neck" }
       },


### PR DESCRIPTION
Historically, the name of the skeleton for headwear was "Headwear_Rig", and for facewear "Facewear_Rig". Since then we changed the headwear and facewear assets' skeleton to be named "Armature". And also deprecated those special names in March last year. We kinda missed to update the validation.

The available template at the [asset creation guide](https://docs.readyplayer.me/ready-player-me/customizing-guides/create-custom-assets/headwear) correctly has the root name "Armature", as well. But the validation wasn't updated yet, so this wrongfully fails validation.
With the root name being "Armature", the asset works just fine (tested in Studio, bypassing current validation).

This PR, therefore replaces "Headwear_Rig" with "Armature" as a valid skeleton root name for headwear joints.
We don't keep "Headwear_Rig" as an allowed root name, because 1. we deprecated it long time ago and would break avatar service, 2. the assets were already changed, and 2. it would require additional changes in the scene validation, that I'd rather not go into, because it make things very complicated with the current schemas.

No update of the docs necessary, since they also already don't mention "Headwear_Rig" and instead show "Armature" as the skeleton root.