### PR TITLE
Feature/no common mesh for custom assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Convert line endings to LF.
+* text=auto eol=lf

--- a/schemas/assetCustom.schema.json
+++ b/schemas/assetCustom.schema.json
@@ -22,26 +22,23 @@
           "type": "array",
           "items": {
             "type": "object",
-            "allOf": [
-              {
-                "$ref": "commonMesh.schema.json"
+            "properties": {
+              "mode": {
+                "description": "The rendering mode of the mesh. Only TRIANGLES are supported.",
+                "type": "array",
+                "prefixItems": [{ "const": "TRIANGLES" }],
+                "minItems": 1,
+                "maxItems": 1,
+                "errorMessage": "Rendering mode must be TRIANGLES."
               }
-            ],
-            "required": [
-              "mode",
-              "primitives",
-              "glPrimitives",
-              "vertices",
-              "indices",
-              "instances",
-              "size"
-            ]
+            },
+            "required": ["mode"]
           },
           "minItems": 1,
           "maxItems": 20,
           "errorMessage": {
-            "minItems": "Missing mesh! Full-body outfit asset must have at least 1 mesh.",
-            "maxItems": "Too many meshes! Full-body outfit asset must have no more than 20 meshes."
+            "minItems": "Missing mesh! Asset must have at least 1 mesh.",
+            "maxItems": "Too many meshes! Asset must have no more than 20 meshes."
           }
         }
       }
@@ -106,8 +103,5 @@
       }
     }
   },
-  "required": [
-    "meshes",
-    "textures"
-  ]
+  "required": ["meshes", "textures"]
 }

--- a/schemas/assetCustom.schema.json
+++ b/schemas/assetCustom.schema.json
@@ -9,7 +9,13 @@
       "type": "object",
       "properties": {
         "totalTriangleCount": {
-          "$ref": "meshTriangleCount.schema.json#/properties/custom"
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 80000,
+          "errorMessage": {
+            "minimum": "Too few triangles! This asset must have at least 1 triangle.",
+            "maximum": "Too many triangles! This asset must not have more than 80000 triangles. Found: ${0}."
+          }
         },
         "properties": {
           "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",

--- a/schemas/meshTriangleCount.schema.json
+++ b/schemas/meshTriangleCount.schema.json
@@ -23,15 +23,6 @@
         "maximum": "Too many triangles! This asset must not have more than 30000 triangles. Found: ${0}."
       }
     },
-    "custom": {
-      "type": "integer",
-      "minimum": 1,
-      "maximum": 80000,
-      "errorMessage": {
-        "minimum": "Too few triangles! This asset must have at least 1 triangle.",
-        "maximum": "Too many triangles! This asset must not have more than 80000 triangles. Found: ${0}."
-      }
-    },
     "facewear": {
       "type": "integer",
       "maximum": 2000,


### PR DESCRIPTION
Custom assets' meshes should not be subject to the validation rules set up for common meshes of Ready Player Me avatars.

Task: PHO-292